### PR TITLE
Make bleak disconnect permanently on disconnect

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches-ignore:
       - main
-  pull_request:
 
 jobs:
   tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embody-ble"
-version = "1.1.3"
+version = "1.1.4"
 description = "Communicate with the EmBody device over BLE (bluetooth)"
 authors = ["Aidee Health AS <hello@aidee.io>"]
 license = "MIT"

--- a/src/embodyble/embodyble.py
+++ b/src/embodyble/embodyble.py
@@ -194,10 +194,10 @@ class EmbodyBle(embodyserial.EmbodySender):
         """Check whether BLE is connected (active handle)"""
         return self.__client is not None and self.__client.is_connected
 
-    async def _on_disconnected(self, client: BleakClient) -> None:
+    def _on_disconnected(self, client: BleakClient) -> None:
         """Invoked by bleak when disconnected."""
         logging.debug(f"Disconnected: {client}")
-        await client.disconnect()
+        asyncio.run_coroutine_threadsafe(client.disconnect(), self.__loop).result()
         self.__notify_connection_listeners(False)
         if self.__reader:
             self.__reader.stop()

--- a/src/embodyble/embodyble.py
+++ b/src/embodyble/embodyble.py
@@ -105,9 +105,12 @@ class EmbodyBle(embodyserial.EmbodySender):
             raise EmbodyBleError(
                 f"Could not find device with name {self.__device_name}"
             )
-        self.__client = BleakClient(device, self.on_disconnected)
+        self.__client = BleakClient(device, self._on_disconnected)
         await self.__client.connect()
-        logging.info(f"Connected: {self.__client}")
+        if self.__client.__class__.__name__ == "BleakClientBlueZDBus":
+            await self.__client._acquire_mtu()
+
+        logging.info(f"Connected: {self.__client}, mtu size: {self.__client.mtu_size}")
         self.__reader = _MessageReader(
             self.__client, self.__message_listeners, self.__ble_message_listeners
         )
@@ -193,9 +196,10 @@ class EmbodyBle(embodyserial.EmbodySender):
         """Check whether BLE is connected (active handle)"""
         return self.__client is not None and self.__client.is_connected
 
-    def on_disconnected(self, client: BleakClient) -> None:
+    async def _on_disconnected(self, client: BleakClient) -> None:
         """Invoked by bleak when disconnected."""
         logging.debug(f"Disconnected: {client}")
+        await client.disconnect()
         self.__notify_connection_listeners(False)
         if self.__reader:
             self.__reader.stop()

--- a/src/embodyble/embodyble.py
+++ b/src/embodyble/embodyble.py
@@ -107,8 +107,6 @@ class EmbodyBle(embodyserial.EmbodySender):
             )
         self.__client = BleakClient(device, self._on_disconnected)
         await self.__client.connect()
-        if self.__client.__class__.__name__ == "BleakClientBlueZDBus":
-            await self.__client._acquire_mtu()
 
         logging.info(f"Connected: {self.__client}, mtu size: {self.__client.mtu_size}")
         self.__reader = _MessageReader(


### PR DESCRIPTION
Seems like bleak runs like a context manager reconnecting if disconnected. Embody-ble is not adapted to this pattern. 

Do an explicit disconnect in the disconnected callback to ensure bleak does not reconnect to the peripheral (EmBody device).